### PR TITLE
Add securityGroups prop to network-load-balanced-fargate-service.ts

### DIFF
--- a/packages/aws-cdk-lib/aws-ecs-patterns/lib/fargate/network-load-balanced-fargate-service.ts
+++ b/packages/aws-cdk-lib/aws-ecs-patterns/lib/fargate/network-load-balanced-fargate-service.ts
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { SubnetSelection } from '../../../aws-ec2';
+import { SubnetSelection, ISecurityGroup } from '../../../aws-ec2';
 import { FargateService, FargateTaskDefinition } from '../../../aws-ecs';
 import { FeatureFlags } from '../../../core';
 import * as cxapi from '../../../cx-api';
@@ -25,6 +25,10 @@ export interface NetworkLoadBalancedFargateServiceProps extends NetworkLoadBalan
    */
   readonly taskSubnets?: SubnetSelection;
 
+  /**
+   * The security groups to associate with the service. If you do not specify a security group, a new security group is created.
+   * */
+  readonly securityGroups?: ISecurityGroup[];
 }
 
 /**
@@ -104,6 +108,7 @@ export class NetworkLoadBalancedFargateService extends NetworkLoadBalancedServic
       vpcSubnets: props.taskSubnets,
       enableExecuteCommand: props.enableExecuteCommand,
       capacityProviderStrategies: props.capacityProviderStrategies,
+      securityGroups: props.securityGroups,
     });
     this.addServiceAsTarget(this.service);
   }


### PR DESCRIPTION
Add securityGroups to the properties so that consumers of this construct have more control over the security groups associated with container instances

Closes #[<9972>.](https://github.com/aws/aws-cdk/issues/9972)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
